### PR TITLE
DS-5749 Fix silent failures in Google Sheets integration

### DIFF
--- a/utils/SpreadSheetGoogle.php
+++ b/utils/SpreadSheetGoogle.php
@@ -34,7 +34,10 @@ class SpreadSheetGoogle
         if ($stripeValues) {
             $values[0] = array_merge($values[0], $stripeValues);
         }
-        write_to_sheet($idSpreadSheet, self::RANGE, $values, $db);
+
+        // Pass Google credentials from global constants
+        global $GOOGLE_CLIENT_ID, $GOOGLE_CLIENT_SECRET;
+        write_to_sheet($idSpreadSheet, self::RANGE, $values, $db, $GOOGLE_CLIENT_ID, $GOOGLE_CLIENT_SECRET);
     }
     private static function getStripeValues($user)
     {

--- a/utils/spread/write.php
+++ b/utils/spread/write.php
@@ -1,20 +1,28 @@
 <?php
 
 
-function write_to_sheet($spreadsheetId, $range, $values, $db) {
+function write_to_sheet($spreadsheetId, $range, $values, $db, $googleClientId = null, $googleClientSecret = null) {
+    // Use global constants if parameters not provided
+    if (!$googleClientId) {
+        global $GOOGLE_CLIENT_ID, $GOOGLE_CLIENT_SECRET;
+        $googleClientId = $GOOGLE_CLIENT_ID;
+        $googleClientSecret = $GOOGLE_CLIENT_SECRET;
+    }
 
-    require_once ('config.php');
+    // Load only the vendor autoload, not the full config
+    require_once ('vendor/autoload.php');
+
     $arr_token = (array) $db->google_oauth_get_access_token();
     $accessToken = array(
         'access_token' => $arr_token['access_token'],
         'expires_in' => $arr_token['expires_in'],
     );
+
     $client = new Google_Client();
     $client->setAccessToken($accessToken);
     $service = new Google_Service_Sheets($client);
 
     try {
-
         $body = new Google_Service_Sheets_ValueRange([
             'values' => $values
         ]);
@@ -31,15 +39,15 @@ function write_to_sheet($spreadsheetId, $range, $values, $db) {
                 'form_params' => [
                     "grant_type" => "refresh_token",
                     "refresh_token" => $refresh_token,
-                    "client_id" => $GOOGLE_CLIENT_ID,
-                    "client_secret" => $GOOGLE_CLIENT_SECRET,
+                    "client_id" => $googleClientId,
+                    "client_secret" => $googleClientSecret,
                 ],
             ]);
 
             $data = (array) json_decode($response->getBody());
             $data['refresh_token'] = $refresh_token;
             $db->google_oauth_update_access_token(json_encode($data));
-            write_to_sheet($spreadsheetId, $range, $values, $db);
+            write_to_sheet($spreadsheetId, $range, $values, $db, $googleClientId, $googleClientSecret);
         } else {
             $error = json_decode($e->getMessage()); //print the error just in case your data is not added.
             throw new Exception($error->error->message);


### PR DESCRIPTION
Credentials are now passed as parameters instead of reloading the config,
resolving issues with silent failures during data sync.

https://makingsense.atlassian.net/browse/DS-5749