### PR TITLE
DS-5778 change modal logic

### DIFF
--- a/components/modal/captor.js
+++ b/components/modal/captor.js
@@ -1,6 +1,7 @@
 import { openModal } from "./openModal.js";
+import { canShowModal } from "./scripts/modalConditions.js";
 
-const EXIT_TOP_THRESHOLD_PX = 8; // px desde el top para considerar "salida"
+const EXIT_TOP_THRESHOLD_PX = 8;
 const SHOW_ONCE_PER_SESSION = true;
 
 const initExitIntentCapture = () => {
@@ -12,10 +13,10 @@ const setupExitIntentForModal = (modalEl) => {
   if (!modalId) return;
 
   const sessionKey = `exitIntentShown:${modalId}`;
-  if (SHOW_ONCE_PER_SESSION && sessionStorage.getItem(sessionKey)) return;
+  if (SHOW_ONCE_PER_SESSION && localStorage.getItem(sessionKey)) return;
 
   const markShownThisSession = () => {
-    sessionStorage.setItem(sessionKey, "1");
+    localStorage.setItem(sessionKey, "1");
   };
 
   const removeExitIntentListeners = () => {
@@ -25,9 +26,14 @@ const setupExitIntentForModal = (modalEl) => {
   };
 
   const triggerModalOnce = () => {
-    markShownThisSession();
-    removeExitIntentListeners();
-    openModal(modalId);
+    if (!canShowModal(modalId)) return;
+    openModal(modalId, {
+      delay: 250,
+      onOpened: () => {
+        markShownThisSession();
+        removeExitIntentListeners();
+      },
+    });
   };
 
   const handleMouseOut = (e) => {

--- a/components/modal/extraDataCaptor.php
+++ b/components/modal/extraDataCaptor.php
@@ -9,8 +9,11 @@ render_modal($formExtradataId, 'extradata',  'form');
   } from '/components/modal/openModal.js';
   const formExtradataId = <?= json_encode($formExtradataId) ?>;
   const KEY = `modalShown:${formExtradataId}`;
-  if (!sessionStorage.getItem(KEY)) {
-    sessionStorage.setItem(KEY, '1');
-    openModal(formExtradataId)
+  if (!localStorage.getItem(KEY)) {
+    localStorage.setItem(KEY, '1');
+
+    openModal(formExtradataId, {
+      delay: 400
+    });
   }
 </script>

--- a/components/modal/modal.css
+++ b/components/modal/modal.css
@@ -54,6 +54,10 @@ body.modal-open {
   min-height: 336px;
 }
 
+.popup-modal__body .error:after {
+  color: #ffffff;
+}
+
 .popup-modal__close {
   position: absolute;
   top: 8px;

--- a/components/modal/openModal.js
+++ b/components/modal/openModal.js
@@ -1,26 +1,23 @@
-import { modalQueue, processing, setProcessing } from "./scripts/modalQueueStore.js";
+let currentModalId = null;
 
-export const openModal = (id) => {
+export const openModal = (id, props = {}) => {
   return new Promise((resolve) => {
-    modalQueue.push({ id, resolve });
-    processQueue();
+    if (currentModalId) {
+      return resolve({ reason: "ignored" });
+    }
+
+    const delay = props.delay || 0;
+
+    setTimeout(() => {
+      _internalOpenModal(id, props).then((res) => {
+        currentModalId = null;
+        resolve(res);
+      });
+    }, delay);
   });
 };
 
-const processQueue = () => {
-  if (processing || modalQueue.length === 0) return;
-
-  const { id, resolve } = modalQueue.shift();
-  setProcessing(true);
-
-  _internalOpenModal(id).then((res) => {
-    resolve(res);
-    setProcessing(false);
-    processQueue();
-  });
-};
-
-const _internalOpenModal = (id) => {
+const _internalOpenModal = (id, props = {}) => {
   return new Promise((resolve) => {
     const overlay = document.getElementById(id);
     if (!overlay) return resolve({ reason: "missing" });
@@ -33,6 +30,7 @@ const _internalOpenModal = (id) => {
       document.removeEventListener("keydown", onEsc);
       observer.disconnect();
       body.classList.remove("modal-open");
+      currentModalId = null;
     };
 
     const finish = (reason) => {
@@ -59,6 +57,11 @@ const _internalOpenModal = (id) => {
 
     overlay.setAttribute("aria-hidden", "false");
     body.classList.add("modal-open");
+    currentModalId = id;
+
+    if (typeof props.onOpened === "function") {
+        props.onOpened();
+    }
 
     overlay.addEventListener("click", onOverlayClick);
     document.addEventListener("keydown", onEsc);

--- a/components/modal/openModal.js
+++ b/components/modal/openModal.js
@@ -60,7 +60,7 @@ const _internalOpenModal = (id, props = {}) => {
     currentModalId = id;
 
     if (typeof props.onOpened === "function") {
-        props.onOpened();
+      props.onOpened();
     }
 
     overlay.addEventListener("click", onOverlayClick);

--- a/components/modal/scripts/modalConditions.js
+++ b/components/modal/scripts/modalConditions.js
@@ -1,0 +1,28 @@
+import { eventsType } from "../../../src/1.0.0/js/enums/eventsType.enum.js";
+import { modalIds } from "./modalIds.enum.js";
+
+const getUserEvents = () => {
+  try {
+    const raw = localStorage.getItem("events");
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+export const canShowModal = (modalId) => {
+  const events = getUserEvents();
+
+  switch (modalId) {
+    case modalIds.VIP:
+      return !events.includes(eventsType.DIGITALTRENDSVIP);
+
+    case modalIds.FORM:
+      return events.includes(eventsType.ECOMMERCE) && !events.includes(eventsType.DIGITALTRENDS);
+
+    case modalIds.EXTRA_DATA:
+      return true;
+
+    default:
+      return true;
+  }
+};

--- a/components/modal/scripts/modalIds.enum.js
+++ b/components/modal/scripts/modalIds.enum.js
@@ -1,0 +1,5 @@
+export const modalIds = Object.freeze({
+  VIP: "modalVip",
+  FORM: "form",
+  EXTRA_DATA: "modalExtraData",
+});

--- a/components/modal/scripts/modalQueueStore.js
+++ b/components/modal/scripts/modalQueueStore.js
@@ -1,6 +1,0 @@
-export const modalQueue = [];
-export let processing = false;
-
-export const setProcessing = (value) => {
-  processing = value;
-};


### PR DESCRIPTION
Este PR actualiza la lógica de apertura de modales con los siguientes cambios principales:

1. **Eliminación de la cola de modales**
   - Antes existía un `modalQueue` que gestionaba múltiples aperturas.
   - Ahora solo se permite un modal abierto a la vez; si se intenta abrir otro, se ignora.

2. **Separación de responsabilidades con `canShowModal`**
   - Se creó un módulo centralizado para definir reglas de sobre cuándo un modal puede mostrarse.
   - Ejemplo: el modal VIP no se abre si el usuario ya tiene el evento `DIGITALTRENDSVIP`.

3. **Enum de IDs de modales**
   - Se definió `modalIds` para centralizar los identificadores de cada modal.

4. **Soporte para delay en apertura de modales**
   - Se agregó la opción `delay` en `openModal`.
   - Permite retrasar la apertura (ej. 500 ms) para evitar aperturas indeseadas en casos de redirecciones rápidas.

5. **Cambio de storage**
   - Se cambia de sessionStorage a localStorage.

