### PR TITLE
DS-5838 restructure customer creation flow and improve registered tracking

### DIFF
--- a/config/redis.php
+++ b/config/redis.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('USE_JOB_QUEUE')) define('USE_JOB_QUEUE', true);
+if (!defined('USE_JOB_QUEUE')) define('USE_JOB_QUEUE', false);
 #REDIS
 $REDIS_HOST = getenv("REDIS_HOST") ?: "redis";
 $REDIS_PORT = getenv("REDIS_PORT") ?: 6379;

--- a/stripe/models/RegisteredDatabase.php
+++ b/stripe/models/RegisteredDatabase.php
@@ -112,15 +112,15 @@ class RegisteredDatabase
             '', // phone
             '', // company
             '', // jobPosition
-            $ecommerceValue,
-            $ecommerceValue, // ecommerce-vip
-            $DTValue,
-            $DTValue, // digital-trends-vip
-            'automated_stripe', // source_utm
-            'automated_stripe', // medium_utm
-            'automated_stripe', // campaign_utm
-            'automated_stripe', // content_utm
-            'automated_stripe'  // term_utm
+            $ecommerceValue,         // ecommerce
+            $ecommerceValue,         // ecommerce-vip
+            $DTValue,                // digital-trends
+            $DTValue,                // digital-trends-vip
+            $registeredData['utm_source'] ?? '',
+            $registeredData['utm_medium'] ?? '',
+            $registeredData['utm_campaign'] ?? '',
+            $registeredData['utm_content'] ?? '',
+            $registeredData['utm_term'] ?? ''
         ];
 
         return Logger::withDatabase($this->db, function($db) use ($query, $params) {

--- a/stripe/models/StripeCustomersDatabase.php
+++ b/stripe/models/StripeCustomersDatabase.php
@@ -60,4 +60,20 @@ class StripeCustomersDatabase
             'action' => 'get_customer_by_email'
         ], 'STRIPE');
     }
+
+    public function getCustomerBySessionId($sessionId)
+    {
+        $query = "SELECT * FROM stripe_customers WHERE session_id = ? LIMIT 1";
+
+        return Logger::withDatabase($this->db, function($db) use ($query, $sessionId) {
+            $result = $db->query($query, [$sessionId]);
+            $customers = $result->fetchAll();
+
+            return !empty($customers) ? $customers[0] : null;
+        }, [
+            'session_id' => $sessionId,
+            'table' => 'stripe_customers',
+            'action' => 'get_customer_by_session_id'
+        ], 'STRIPE');
+    }
 }


### PR DESCRIPTION
Refactor:

- Nuevo método `getCustomerBySessionId()` en `StripeCustomersDatabase`.
- Refactor en `StripeCustomersController` para manejar flujos FREE/VIP.
- Nuevos helpers `prepareUserDataFree` y `prepareUserDataVip`.
- Logger extendido con `is_new_user` y manejo de errores detallado.
- Ajuste en `RegisteredDatabase` para guardar UTM dinámicos.
- `USE_JOB_QUEUE` temporalmente desactivado en `config/redis.php` a nivel repo para entorno dev.